### PR TITLE
Fix line number grab

### DIFF
--- a/lib/wish.js
+++ b/lib/wish.js
@@ -82,7 +82,7 @@ module.exports = (function(){
   };
 
   function createLineFromErrorObject(){
-      const stackLevel = 7;
+      const stackLevel = 6;
       const line = {};
       line.full = getErrorObject().stack.split("\n")[stackLevel];
       line.fileName = line.full.match(/(\/.*\.js)/)[1];

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "description": "Assertions without special syntax",
   "version": "0.1.2",
   "devDependencies": {
-    "mocha": "*"
+    "deep-equal": "^1.0.1",
+    "mocha": "~1.8.2"
   },
   "scripts": {
     "test": "make test"
@@ -14,9 +15,6 @@
   "directories": {
     "doc": "docs",
     "test": "test"
-  },
-  "devDependencies": {
-    "mocha": "~1.8.2"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Added back deep-equal and fixed line choice made from error stack so that correct method is returned.

Before, 19 of 21 tests failed. Now all tests pass.